### PR TITLE
feat: Upgrade Audacia.Random to dotnet 10 #204014

### DIFF
--- a/Audacia.Random.Tests/Audacia.Random.Tests.csproj
+++ b/Audacia.Random.Tests/Audacia.Random.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<ProjectGuid>{395F1798-81EF-46CD-A27B-AED15FC67F04}</ProjectGuid>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-		<PackageReference Include="xunit" Version="2.3.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Audacia.Random/Audacia.Random.csproj
+++ b/Audacia.Random/Audacia.Random.csproj
@@ -4,7 +4,7 @@
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
     <SccLocalPath>SAK</SccLocalPath>
-    <TargetFrameworks>netstandard1.2;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RepositoryUrl>https://github.com/audaciaconsulting/Audacia.Random</RepositoryUrl>
     <ProjectGuid>{2004CD59-BEB0-46B1-8265-DF351E1023CE}</ProjectGuid>
     <SignAssembly>true</SignAssembly>

--- a/Audacia.Random/Audacia.Random.csproj
+++ b/Audacia.Random/Audacia.Random.csproj
@@ -11,7 +11,7 @@
     <DelaySign>true</DelaySign>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>3.1.21077</Version>
+    <Version>4.0.0</Version>
     <Authors>Audacia</Authors>
     <Company>Audacia</Company>
     <PackageIconUrl>https://www.audacia.co.uk/media/pkenoobu/audacia-logo-circle-blue.png</PackageIconUrl>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ﻿# Changelog
 
+## 4.0.0 - 2025-01-23
+### Added
+- No new functionality added
+
+### Changed
+- Updated target framework to .NET Standard 2.0 only (removed .NET Standard 1.2 support)
+- Updated test project to .NET 10.0
+- Updated NuGet dependencies in test project to latest versions:
+  - Microsoft.NET.Test.Sdk: 15.8.0 → 17.12.0
+  - xunit: 2.3.1 → 2.9.2
+  - xunit.runner.visualstudio: 2.3.1 → 2.8.2
+
+### Fixed
+- No bug fixes
+
 ## 3.1.21077 - 2023-10-12
 ### Added
 - No new functionality added

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 [![NuGet](https://img.shields.io/nuget/v/Audacia.Random.svg)](https://www.nuget.org/packages/Audacia.Random)
 [![CodeFactor](https://www.codefactor.io/repository/github/audaciaconsulting/audacia.random/badge)](https://www.codefactor.io/repository/github/audaciaconsulting/audacia.random)
 
+## Target Framework
+
+This library targets **.NET Standard 2.0**, making it compatible with:
+- .NET Core 2.0 and later
+- .NET Framework 4.6.1 and later
+- .NET 5.0 and later (including .NET 6, 7, 8, 9, 10+)
+
+**Note:** As of version 4.0.0, .NET Standard 1.2 support has been removed. If you require .NET Standard 1.2 compatibility, please use version 3.x.
+
 ## Extension Methods
 
 There are a variety of extension methods available for the `System.Random` class. These are listed below:


### PR DESCRIPTION
### Version changed and CHANGELOG updated
- ✔ New version set in the project file(s) `.csproj` or `Directory.Build.props` and version documented in the CHANGELOG
We removed .NET Standard 1.2 support (a breaking change for the library itself), so I've incremented the major version from 3.1.21077 to 4.0.0.

### Code ready for review
- ✔ Code compiles, all tests pass, no debug/console statements or commented out code left in

### Unit tests added/updated
- ❎ No code changed

### README or other documentation updated
- ✔ Documentation updated to reflect the changes made

### Dependency licenses
- ✔ Licenses of new/upgraded dependencies checked, with no copyleft dependencies introduced

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR